### PR TITLE
Add SKULookup

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -1,0 +1,9 @@
+import com.google.inject.AbstractModule
+import services.{HTTPClient, SKULookup}
+
+class Module extends AbstractModule {
+  def configure() = {
+      bind(classOf[HTTPClient])
+        .to(classOf[SKULookup])
+    }
+}

--- a/app/model/SKU.scala
+++ b/app/model/SKU.scala
@@ -1,0 +1,51 @@
+package model
+
+import play.api.libs.json.Json
+
+case class Price(priceMicros: String, currency: String)
+
+case class Listing(title: String, description: String)
+
+case class SeasonDate(month: Int, day: Int)
+
+case class Proration(start: SeasonDate, defaultPrice: Price)
+
+case class Season(start: SeasonDate,
+                  end: SeasonDate,
+                  prorations: Option[List[Proration]])
+
+case class SKU(packageName: String,
+               sku: String,
+               status: String,
+               purchaseType: String,
+               defaultPrice: Price,
+               prices: Map[String, Price],
+               listings: Map[String, Listing],
+               defaultLanguage: String,
+               subscriptionPeriod: String,
+               season: Season,
+               trialPeriod: String)
+
+object Price {
+  implicit val format = Json.format[Price]
+}
+
+object Listing {
+  implicit val format = Json.format[Listing]
+}
+
+object SeasonDate {
+  implicit val format = Json.format[SeasonDate]
+}
+
+object Proration {
+  implicit val format = Json.format[Proration]
+}
+
+object Season {
+  implicit val format = Json.format[Season]
+}
+
+object SKU {
+  implicit val format = Json.format[SKU]
+}

--- a/app/services/SKULookup.scala
+++ b/app/services/SKULookup.scala
@@ -12,9 +12,9 @@ import model._
 
 trait HTTPClient
 
-case class SKULookupError(status: Int, message: String) extends Exception
+case class SKULookupException(status: Int, message: String) extends Exception
 
-case class SKULookupDeserialisationError(
+case class SKULookupDeserialisationErrorException(
   message: String,
   errors: Seq[(JsPath, Seq[JsonValidationError])]
 ) extends Exception
@@ -43,11 +43,11 @@ class SKULookup @Inject()(wsClient: WSClient, config: Configuration)(
       .addHttpHeaders("Authorization" -> accessToken)
       .get() map { response => {
         if (response.status != Status.OK) {
-          Left(SKULookupError(response.status, "Server error"))
+          Left(SKULookupException(response.status, "Server error"))
         } else {
           Json.parse(response.body).validate[SKU].asEither match {
             case Left(l) =>
-              Left(SKULookupDeserialisationError("Error deserialising JSON", l))
+              Left(SKULookupDeserialisationErrorException("Error deserialising JSON", l))
             case Right(r) => Right(r)
           }
         }

--- a/app/services/SKULookup.scala
+++ b/app/services/SKULookup.scala
@@ -1,0 +1,49 @@
+package services
+
+import javax.inject._
+import play.api.Configuration
+import play.api.libs.json.{JsResultException, JsValue}
+import play.api.libs.ws._
+import play.api.Logger
+
+import scala.concurrent.{ExecutionContext, Future}
+import model._
+
+trait HTTPClient
+
+@Singleton
+class SKULookup @Inject() (wsClient: WSClient, config: Configuration)(
+  implicit executionContext: ExecutionContext
+) extends HTTPClient {
+  val logger: Logger = Logger(this.getClass())
+
+  def get(sku: String): Future[Either[String, SKU]] = {
+    val skuBaseUrl = config.get[String]("google.apiUrl")
+    val accessToken = config.get[String]("google.playDeveloperAccessToken")
+
+    val packageName = "com.theguardian.com"
+    val url = s"$skuBaseUrl/$packageName/inappproducts/$sku"
+
+    getRequest(wsClient, url, accessToken)
+  }
+
+  def getRequest(wsClient: WSClient, url: String, accessToken: String): Future[Either[String, SKU]] =
+    wsClient
+      .url(url).addHttpHeaders("Authorization" -> accessToken)
+      .get() map { response ⇒
+        if (response.status >= 400) {
+          Left(response.body)
+        } else {
+          Right(response.body[JsValue].as[SKU])
+        }
+      } recover {
+        case exception: JsResultException => {
+          val errorTitle = "Error deserialising SKU"
+          val errorMessage = exception.errors.map(err => s"field: ${err._1}, errors: ${err._2}.").mkString(" ")
+
+          logger.error(s"$errorTitle. $errorMessage")
+          Left(errorTitle)
+        }
+        case error: Exception => Left(error.toString)
+      }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,10 @@ val enumeratumPlayJsonVersion = "1.5.14"
 libraryDependencies ++= Seq(
   guice,
   "com.beachape" %% "enumeratum-play-json" % enumeratumPlayJsonVersion,
-  "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test
+  ws,
+  ehcache,
+  "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
+  "de.leanovate.play-mockws" %% "play-mockws" % "2.6.2" % Test
 )
 
 topLevelDirectory in Universal := None

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,1 +1,4 @@
 # https://www.playframework.com/documentation/latest/Configuration
+
+google.apiUrl="https://www.googleapis.com/androidpublisher/v3/applications"
+google.playDeveloperAccessToken=""

--- a/test/services/SKULookupSpec.scala
+++ b/test/services/SKULookupSpec.scala
@@ -25,6 +25,9 @@ class SKULookupSpec extends WordSpecLike with Matchers with ScalaFutures {
       )
     )
 
+    val timeout = Timeout(Span(500, Millis))
+    val interval = Interval(Span(25, Millis))
+
     "Retrieve and deserialise a SKU" in {
       val ws = MockWS {
         case (
@@ -47,9 +50,6 @@ class SKULookupSpec extends WordSpecLike with Matchers with ScalaFutures {
       }
 
       val skuLookup = new SKULookup(ws, configuration)
-
-      val timeout = Timeout(Span(500, Millis))
-      val interval = Interval(Span(25, Millis))
 
       whenReady(skuLookup.get("skuCode"), timeout, interval) { result =>
         result.right.get shouldBe SKU(
@@ -84,9 +84,6 @@ class SKULookupSpec extends WordSpecLike with Matchers with ScalaFutures {
       }
 
       val skuLookup = new SKULookup(ws, configuration)
-
-      val timeout = Timeout(Span(500, Millis))
-      val interval = Interval(Span(25, Millis))
 
       whenReady(skuLookup.get("skuCode"), timeout, interval) { result =>
         result.left.get shouldBe a[SKULookupDeserialisationError]

--- a/test/services/SKULookupSpec.scala
+++ b/test/services/SKULookupSpec.scala
@@ -1,0 +1,109 @@
+package services
+
+import mockws.MockWS
+import model._
+import org.scalatest.{Matchers, WordSpecLike}
+import play.api.Configuration
+import play.api.mvc.Action
+import play.api.mvc.Results.{Ok, InternalServerError}
+import play.api.test.Helpers._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class SKULookupSpec extends WordSpecLike with Matchers {
+  "SKULookup" must {
+
+    val configuration = Configuration.from(
+      Map(
+        "google.apiUrl" -> "http://someMockUrl",
+        "google.playDeveloperAccessToken" -> "someAccessToken"
+      )
+    )
+
+    "Retrieve and deserialise a SKU" in {
+      val ws = MockWS {
+        case (GET, "http://someMockUrl/com.theguardian.com/inappproducts/skuCode") =>
+          Action {
+            Ok(
+              s"""{"packageName": "packageName",
+                 |"sku": "skuCode",
+                 |"status": "status",
+                 |"purchaseType": "subscription",
+                 |"defaultPrice": {"priceMicros": "2500000", "currency": "GBP"},
+                 |"prices": {"GB": {"priceMicros": "2500000", "currency": "GBP"}},
+                 |"listings": {"en-GB": {"title": "title", "description": "description"}},
+                 |"defaultLanguage": "default language",
+                 |"subscriptionPeriod": "P1M",
+                 |"season": {"start": {"month":1, "day":1}, "end": {"month":1, "day":1}, "prorations": [{"start": {"month":1, "day":1}, "defaultPrice": {"priceMicros": "2500000", "currency": "GBP"}}]},
+                 |"trialPeriod": "P5D"}""".stripMargin
+            )
+          }
+      }
+
+      val skuLookup = new SKULookup(
+        ws,
+        configuration
+      )
+
+      val result = Await.result(skuLookup.get("skuCode"), 500 millis)
+
+      result shouldBe Right(
+        SKU(
+          "packageName",
+          "skuCode",
+          "status",
+          "subscription",
+          Price("2500000", "GBP"),
+          Map("GB" -> Price("2500000", "GBP")),
+          Map("en-GB" -> Listing("title", "description")),
+          "default language",
+          "P1M",
+          Season(
+            SeasonDate(1, 1),
+            SeasonDate(1, 1),
+            Some(List(Proration(SeasonDate(1, 1), Price("2500000", "GBP"))))
+          ),
+          "P5D"
+        )
+      )
+    }
+
+    "Fail with invalid JSON" in {
+      val ws = MockWS {
+        case (GET, "http://someMockUrl/com.theguardian.com/inappproducts/skuCode") =>
+          Action {
+            Ok(s"""{"packageName": "packageName"}""")
+          }
+      }
+
+      val skuLookup = new SKULookup(
+        ws,
+        configuration
+      )
+
+      val result = Await.result(skuLookup.get("skuCode"), 500 millis)
+
+      result shouldBe Left("Error deserialising SKU")
+    }
+
+    "Fail if HTTP request fails" in {
+      val ws = MockWS {
+        case (GET, "http://someMockUrl/com.theguardian.com/inappproducts/skuCode") =>
+          Action {
+            InternalServerError("Some Server Error")
+          }
+      }
+
+      val skuLookup = new SKULookup(
+        ws,
+        configuration
+      )
+
+      val result = Await.result(skuLookup.get("skuCode"), 500 millis)
+
+      result shouldBe Left("Some Server Error")
+    }
+  }
+}

--- a/test/services/SKULookupSpec.scala
+++ b/test/services/SKULookupSpec.scala
@@ -86,7 +86,7 @@ class SKULookupSpec extends WordSpecLike with Matchers with ScalaFutures {
       val skuLookup = new SKULookup(ws, configuration)
 
       whenReady(skuLookup.get("skuCode"), timeout, interval) { result =>
-        result.left.get shouldBe a[SKULookupDeserialisationError]
+        result.left.get shouldBe a[SKULookupDeserialisationErrorException]
       }
     }
 
@@ -104,7 +104,7 @@ class SKULookupSpec extends WordSpecLike with Matchers with ScalaFutures {
       val skuLookup = new SKULookup(ws, configuration)
 
       whenReady(skuLookup.get("skuCode")) { result =>
-        result.left.get shouldBe SKULookupError(
+        result.left.get shouldBe SKULookupException(
           INTERNAL_SERVER_ERROR,
           "Server error"
         )


### PR DESCRIPTION
This allows us to retrieve details about a product/SKU when receiving pub/sub notifications.

Useful for:
* Verifying payments
* Enriching data which will be passed onto the Payments API.

Changes:
* Add `SKU` case class
* Add `SKULookup.get(skuCode)` which returns `Either[String, SKU]`
* Add `google.apiUrl` and `google.playDeveloperAccessToken` configs params

Additional things that could be added later:
* Caching

Trello Card:
https://trello.com/c/CRoo535n/66-retrieve-skus-from-playstore

Google docs:
https://developers.google.com/android-publisher/api-ref/inappproducts/get