### PR TITLE
Google refresh access token mechanism

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -2,7 +2,7 @@ import com.google.inject.AbstractModule
 import services.{HTTPClient, GoogleHTTPClient}
 
 class Module extends AbstractModule {
-  def configure(): Unit = {
+  override def configure(): Unit = {
       bind(classOf[HTTPClient])
         .to(classOf[GoogleHTTPClient])
     }

--- a/app/Module.scala
+++ b/app/Module.scala
@@ -1,9 +1,12 @@
 import com.google.inject.AbstractModule
-import services.{HTTPClient, GoogleHTTPClient}
+import services.{AccessTokenClient, GoogleAccessTokenClient, GoogleHTTPClient, HTTPClient}
 
 class Module extends AbstractModule {
   override def configure(): Unit = {
-      bind(classOf[HTTPClient])
-        .to(classOf[GoogleHTTPClient])
+    bind(classOf[HTTPClient])
+      .to(classOf[GoogleHTTPClient])
+
+    bind(classOf[AccessTokenClient])
+      .to(classOf[GoogleAccessTokenClient])
     }
 }

--- a/app/model/GoogleAccessToken.scala
+++ b/app/model/GoogleAccessToken.scala
@@ -1,0 +1,10 @@
+package model
+import play.api.libs.json.JsonNaming.SnakeCase
+import play.api.libs.json.{Json, JsonConfiguration}
+
+case class GoogleAccessToken(accessToken: String, expiresIn: Int, scope: String, tokenType: String)
+
+object GoogleAccessToken {
+  implicit val config = JsonConfiguration(SnakeCase)
+  implicit val format = Json.format[GoogleAccessToken]
+}

--- a/app/services/GoogleAccessTokenClient.scala
+++ b/app/services/GoogleAccessTokenClient.scala
@@ -29,24 +29,24 @@ class GoogleAccessTokenClient @Inject()(
   val swgClientSecret = config.get[String]("swg.clientSecret")
   val swgRedirectUri = config.get[String]("swg.redirectUri")
 
-  def get(): Future[GoogleAccessToken] = {
-    val cache: AsyncLoadingCache[String, GoogleAccessToken] =
-      Scaffeine()
-        .recordStats()
-        .maximumSize(1)
-        .expireAfter(
-          create = (_: String, accessToken: GoogleAccessToken) =>
-            accessToken.expiresIn seconds,
-          update =
-            (_: String, _: GoogleAccessToken, currentDuration: Duration) =>
-              currentDuration,
-          read = (_: String, _: GoogleAccessToken, currentDuration: Duration) =>
-            currentDuration
-        )
-        .buildAsyncFuture[String, GoogleAccessToken](
-          (_: String) => getAccessTokenRequest()
-        )
+  val cache: AsyncLoadingCache[String, GoogleAccessToken] =
+    Scaffeine()
+      .recordStats()
+      .maximumSize(1)
+      .expireAfter(
+        create = (_: String, accessToken: GoogleAccessToken) =>
+          accessToken.expiresIn seconds,
+        update =
+          (_: String, _: GoogleAccessToken, currentDuration: Duration) =>
+            currentDuration,
+        read = (_: String, _: GoogleAccessToken, currentDuration: Duration) =>
+          currentDuration
+      )
+      .buildAsyncFuture[String, GoogleAccessToken](
+        (_: String) => getAccessTokenRequest()
+      )
 
+  def get(): Future[GoogleAccessToken] = {
     cache.get("accessToken")
   }
 

--- a/app/services/GoogleAccessTokenClient.scala
+++ b/app/services/GoogleAccessTokenClient.scala
@@ -1,0 +1,60 @@
+package services
+import exceptions.{DeserializationException, GoogleHTTPClientDeserialisationException, GoogleHTTPClientException}
+import javax.inject.{Inject, Singleton}
+import model.GoogleAccessToken
+import play.api.Configuration
+import play.api.http.Status
+import play.api.libs.json.Json
+import play.api.libs.ws.WSClient
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait AccessTokenClient {
+  def get(): Future[Either[Exception, String]]
+}
+
+@Singleton
+class GoogleAccessTokenClient @Inject()(
+  wsClient: WSClient,
+  config: Configuration
+)(implicit executionContext: ExecutionContext)
+    extends AccessTokenClient {
+  val apiTokenUrl = "https://accounts.google.com/o/oauth2/token"
+
+  val refreshToken = config.get[String]("google.playDeveloperRefreshToken")
+  val swgClientId = config.get[String]("swg.clientId")
+  val swgClientSecret = config.get[String]("swg.clientSecret")
+  val swgRedirectUri = config.get[String]("swg.redirectUri")
+
+  def get(): Future[Either[Exception, String]] = {
+    val params = Seq(
+      "grant_type" -> "refresh_token",
+      "refresh_token" -> refreshToken,
+      "client_id" -> swgClientId,
+      "client_secret" -> swgClientSecret,
+      "redirect_uri" -> swgRedirectUri
+    )
+
+    wsClient
+      .url(apiTokenUrl)
+      .withQueryStringParameters(params: _*)
+      .get() map { response =>
+      {
+        if (response.status != Status.OK) {
+          Left(GoogleHTTPClientException(response.status, "Server error"))
+        } else {
+          Json.parse(response.body).validate[GoogleAccessToken].asEither match {
+            case Left(l) =>
+              Left(
+                DeserializationException(
+                  "Error deserialising Google access token JSON",
+                  l
+                )
+              )
+            case Right(r) => Right(r.accessToken)
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/services/GoogleHTTPClient.scala
+++ b/app/services/GoogleHTTPClient.scala
@@ -1,9 +1,6 @@
 package services
 
-import exceptions.{
-  GoogleHTTPClientDeserialisationException,
-  GoogleHTTPClientException
-}
+import exceptions.{GoogleHTTPClientDeserialisationException, GoogleHTTPClientException}
 import javax.inject._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -11,7 +8,7 @@ import play.api.Configuration
 import play.api.libs.json._
 import play.api.libs.ws._
 import play.api.http.Status
-import model.{SKU, SubscriptionPurchase}
+import model.{GoogleAccessToken, SKU, SubscriptionPurchase}
 
 trait HTTPClient
 
@@ -42,8 +39,8 @@ class GoogleHTTPClient @Inject()(wsClient: WSClient, accessTokenClient: AccessTo
     val url = s"$apiBaseUrl/$packageName/$relativeUrl"
 
     accessTokenClient.get() flatMap {
-      case Right(accessToken: String) =>
-        getRequestWithAccessToken[A](wsClient, url, accessToken)
+      case Right(accessToken: GoogleAccessToken) =>
+        getRequestWithAccessToken[A](wsClient, url, accessToken.accessToken)
       case Left(l) => Future.successful(Left(l))
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ libraryDependencies ++= Seq(
   "com.beachape" %% "enumeratum-play-json" % enumeratumPlayJsonVersion,
   ws,
   caffeine,
+  "com.github.blemale" %% "scaffeine" % "2.5.0" % "compile",
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
   "de.leanovate.play-mockws" %% "play-mockws" % "2.6.2" % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ libraryDependencies ++= Seq(
   guice,
   "com.beachape" %% "enumeratum-play-json" % enumeratumPlayJsonVersion,
   ws,
-  ehcache,
+  caffeine,
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
   "de.leanovate.play-mockws" %% "play-mockws" % "2.6.2" % Test
 )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,15 +1,15 @@
 # https://www.playframework.com/documentation/latest/Configuration
 
 play.http.secret.key="nowchangeme"
-play.http.secret.key=${?APP_SECRET}
-
-//instance.ip=127.0.0.1
-//instance.ip=${?INSTANCE_IP}
+play.http.secret.key=${?APP_SECRET} 
 
 play.filters.hosts {
   allowed = ["localhost", ".theguardian.com", ${?INSTANCE_ID}]
 }
 
 google.packageName="com.theguardian.com"
-google.apiUrl="https://www.googleapis.com/androidpublisher/v3/applications"
-google.playDeveloperAccessToken=""
+google.playDeveloperRefreshToken="1/aweJxgisp-LaGh4oSFynLEKgM8xXAWP5vHfb9FnT4Ns"
+
+swg.clientId="774465807556-dtgkn8j6ugke7e09a5oaspjqtnjol9uh.apps.googleusercontent.com"
+swg.clientSecret="iQpUJaY0P0hNexjL0_KQE502"
+swg.redirectUri="https://swg.theguardian.com"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.16")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.21")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.0")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.0.0")
 

--- a/test/services/GoogleAccessTokenClientSpec.scala
+++ b/test/services/GoogleAccessTokenClientSpec.scala
@@ -48,9 +48,8 @@ class GoogleAccessTokenClientSpec
       val googleAccessTokenClient =
         new GoogleAccessTokenClient(ws, configuration)
 
-      whenReady(googleAccessTokenClient.get(), timeout, interval) {
-        case Left(l) => fail(l)
-        case Right(r) => r shouldBe "someAccessToken"
+      whenReady(googleAccessTokenClient.get(), timeout, interval) { response =>
+        response.accessToken shouldBe "someAccessToken"
       }
     }
 
@@ -67,9 +66,9 @@ class GoogleAccessTokenClientSpec
       val googleAccessTokenClient =
         new GoogleAccessTokenClient(ws, configuration)
 
-      whenReady(googleAccessTokenClient.get(), timeout, interval) {
-        result =>
-          result.left.get shouldBe a[DeserializationException]
+      whenReady(googleAccessTokenClient.get() failed, timeout, interval) {
+        response =>
+          response shouldBe an [DeserializationException]
       }
     }
 
@@ -84,8 +83,8 @@ class GoogleAccessTokenClientSpec
       val googleAccessTokenClient =
         new GoogleAccessTokenClient(ws, configuration)
 
-      whenReady(googleAccessTokenClient.get()) { result =>
-        result.left.get shouldBe GoogleHTTPClientException(
+      whenReady(googleAccessTokenClient.get() failed) { result =>
+        result shouldBe GoogleHTTPClientException(
           INTERNAL_SERVER_ERROR,
           "Server error"
         )

--- a/test/services/GoogleAccessTokenClientSpec.scala
+++ b/test/services/GoogleAccessTokenClientSpec.scala
@@ -1,0 +1,95 @@
+package services
+
+import exceptions.{DeserializationException, GoogleHTTPClientDeserialisationException, GoogleHTTPClientException}
+import mockws.MockWS
+import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Span}
+import org.scalatest.{Matchers, WordSpecLike}
+import play.api.Configuration
+import play.api.mvc.Results.{InternalServerError, Ok}
+import play.api.test.Helpers._
+import utils.MockWSHelper
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class GoogleAccessTokenClientSpec
+    extends WordSpecLike
+    with Matchers
+    with ScalaFutures
+    with MockWSHelper {
+  "Access Token" must {
+    val configuration = Configuration.from(
+      Map(
+        "google.packageName" -> "somePackageName",
+        "google.playDeveloperRefreshToken" -> "someRefreshToken",
+        "swg.clientId" -> "someClientId",
+        "swg.clientSecret" -> "someClientSecret",
+        "swg.redirectUri" -> "someRedirectUri",
+      )
+    )
+
+    val timeout = Timeout(Span(1000, Millis))
+    val interval = Interval(Span(25, Millis))
+
+    "Retrieve and deserialise an Access Token" in {
+      val ws = MockWS {
+        case (GET, "https://accounts.google.com/o/oauth2/token") =>
+          Action {
+            Ok(s"""{
+                  |"access_token": "someAccessToken",
+                  |"expires_in": 3600,
+                  |"scope": "https://www.googleapis.com/auth/androidpublisher",
+                  |"token_type": "Bearer"
+                  |}""".stripMargin)
+          }
+      }
+
+      val googleAccessTokenClient =
+        new GoogleAccessTokenClient(ws, configuration)
+
+      whenReady(googleAccessTokenClient.get(), timeout, interval) {
+        case Left(l) => fail(l)
+        case Right(r) => r shouldBe "someAccessToken"
+      }
+    }
+
+    "Fail with invalid JSON" in {
+      val ws = MockWS {
+        case (GET, "https://accounts.google.com/o/oauth2/token") =>
+          Action {
+            Ok(s"""{
+                  |"access_token": "someAccessToken"
+                  }""".stripMargin)
+          }
+      }
+
+      val googleAccessTokenClient =
+        new GoogleAccessTokenClient(ws, configuration)
+
+      whenReady(googleAccessTokenClient.get(), timeout, interval) {
+        result =>
+          result.left.get shouldBe a[DeserializationException]
+      }
+    }
+
+    "Fail if HTTP request fails" in {
+      val ws = MockWS {
+        case (GET, "https://accounts.google.com/o/oauth2/token") =>
+          Action {
+            InternalServerError("Some Server Error")
+          }
+      }
+
+      val googleAccessTokenClient =
+        new GoogleAccessTokenClient(ws, configuration)
+
+      whenReady(googleAccessTokenClient.get()) { result =>
+        result.left.get shouldBe GoogleHTTPClientException(
+          INTERNAL_SERVER_ERROR,
+          "Server error"
+        )
+      }
+    }
+  }
+}

--- a/test/services/GoogleHTTPClientSpec.scala
+++ b/test/services/GoogleHTTPClientSpec.scala
@@ -22,7 +22,7 @@ class GoogleHTTPClientSpec
     with MockWSHelper {
 
   class MockAccessTokenClient extends AccessTokenClient {
-    def get() = Future.successful(Right("someAccessToken"))
+    def get() = Future.successful(GoogleAccessToken("someAccessToken", 1, "someScope", "someType"))
   }
 
   val mockAccessTokenClient = new MockAccessTokenClient()
@@ -63,7 +63,7 @@ class GoogleHTTPClientSpec
 
       whenReady(googleHttpClient.getSKU("skuCode"), timeout, interval) {
         result =>
-          result.right.get shouldBe SKU(
+          result shouldBe SKU(
             "packageName",
             "skuCode",
             "status",
@@ -96,9 +96,9 @@ class GoogleHTTPClientSpec
 
       val googleHttpClient = new GoogleHTTPClient(ws, mockAccessTokenClient, configuration)
 
-      whenReady(googleHttpClient.getSKU("skuCode"), timeout, interval) {
+      whenReady(googleHttpClient.getSKU("skuCode") failed, timeout, interval) {
         result =>
-          result.left.get shouldBe a[GoogleHTTPClientDeserialisationException]
+          result shouldBe an [GoogleHTTPClientDeserialisationException]
       }
     }
 
@@ -115,8 +115,8 @@ class GoogleHTTPClientSpec
 
       val googleHttpClient = new GoogleHTTPClient(ws, mockAccessTokenClient, configuration)
 
-      whenReady(googleHttpClient.getSKU("skuCode")) { result =>
-        result.left.get shouldBe GoogleHTTPClientException(
+      whenReady(googleHttpClient.getSKU("skuCode") failed) { result =>
+        result shouldBe GoogleHTTPClientException(
           INTERNAL_SERVER_ERROR,
           "Server error"
         )
@@ -182,7 +182,7 @@ class GoogleHTTPClientSpec
         timeout,
         interval
       ) { result =>
-        result.right.get shouldBe SubscriptionPurchase(
+        result shouldBe SubscriptionPurchase(
           "androidpublisher#subscriptionPurchase",
           1,
           1,
@@ -222,11 +222,11 @@ class GoogleHTTPClientSpec
 
       whenReady(
         googleHttpClient
-          .getSubscriptionPurchase("someProductId", "somePurchaseToken"),
+          .getSubscriptionPurchase("someProductId", "somePurchaseToken") failed,
         timeout,
         interval
       ) { result =>
-        result.left.get shouldBe a[GoogleHTTPClientDeserialisationException]
+        result shouldBe a[GoogleHTTPClientDeserialisationException]
       }
     }
 
@@ -245,9 +245,9 @@ class GoogleHTTPClientSpec
 
       whenReady(
         subPurchaseLookup
-          .getSubscriptionPurchase("someProductId", "somePurchaseToken")
+          .getSubscriptionPurchase("someProductId", "somePurchaseToken") failed
       ) { result =>
-        result.left.get shouldBe GoogleHTTPClientException(
+        result shouldBe GoogleHTTPClientException(
           INTERNAL_SERVER_ERROR,
           "Server error"
         )

--- a/test/services/GoogleHTTPClientSpec.scala
+++ b/test/services/GoogleHTTPClientSpec.scala
@@ -8,13 +8,13 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Span}
 import org.scalatest.{Matchers, WordSpecLike}
 import play.api.Configuration
-import play.api.mvc.Action
 import play.api.mvc.Results.{InternalServerError, Ok}
 import play.api.test.Helpers._
+import utils.MockWSHelper
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class GoogleHTTPClientSpec extends WordSpecLike with Matchers with ScalaFutures {
+class GoogleHTTPClientSpec extends WordSpecLike with Matchers with ScalaFutures with MockWSHelper {
   "SKUs" must {
 
     val configuration = Configuration.from(

--- a/test/utils/MockWSHelper.scala
+++ b/test/utils/MockWSHelper.scala
@@ -1,0 +1,24 @@
+package utils
+
+import akka.actor.{ActorSystem, Terminated}
+import akka.stream.ActorMaterializer
+import play.api.mvc.{DefaultActionBuilder, PlayBodyParsers}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+  * See https://github.com/leanovate/play-mockws/issues/29
+  */
+trait MockWSHelper {
+  private implicit val sys = ActorSystem("test")
+  private implicit val mat = ActorMaterializer()
+
+  val BodyParser: PlayBodyParsers = PlayBodyParsers()
+  val Action: DefaultActionBuilder = DefaultActionBuilder(BodyParser.anyContent)(mat.executionContext)
+
+  def afterAll: Terminated = {
+    mat.shutdown()
+    Await.result(sys.terminate(), 10.seconds)
+  }
+}


### PR DESCRIPTION
Allows us to get a fresh access token using the refresh token from config:
```scala
GoogleAccessToken.get() map { _.accessToken }
```
The returned access token will be cached according to the accompanying `expires_at`. 
Used by `GoogleHttpClient.getSKU` and `GoogleHttpClient.getSubscriptionPurchase`

Adds
* `GoogleAccessToken` model
* `GoogleAccessTokenClient` to retrieve and cache access token 