### PR TITLE
Update credentials to use new Play based client id

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -19,10 +19,10 @@ play.filters.cors {
 
 google.packageName="com.guardian"
 
-google.playDeveloperRefreshToken="1/aweJxgisp-LaGh4oSFynLEKgM8xXAWP5vHfb9FnT4Ns"
+google.playDeveloperRefreshToken="1/OUOp-r-UCz7BzcGujBYzAy3Wcw04cWJ2SpJqDUR5XG4"
 
-swg.clientId="774465807556-dtgkn8j6ugke7e09a5oaspjqtnjol9uh.apps.googleusercontent.com"
-swg.clientSecret="iQpUJaY0P0hNexjL0_KQE502"
+swg.clientId="1066755233532-nlkhfnv51ldiu874khgsrje33r04vt87.apps.googleusercontent.com"
+swg.clientSecret="qeejl6P7OJxZ-REXxku2fEyZ"
 swg.redirectUri="https://swg.theguardian.com"
 
 


### PR DESCRIPTION
These are credentials from the "Google Play Android Developer" project.

This allows us to talk to Google APIs because the Play account is linked to this project. 