### PR TITLE
Update notification types

### DIFF
--- a/app/controllers/PushHandlerController.scala
+++ b/app/controllers/PushHandlerController.scala
@@ -2,16 +2,18 @@ package controllers
 
 import java.nio.channels.NonReadableChannelException
 
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import exceptions.{DeserializationException, NonJsonBodyException}
 import javax.inject.{Inject, Singleton}
 import model.{DeveloperNotification, GooglePushMessageWrapper}
 import play.api.libs.json._
 import play.api.mvc._
 import play.api.Logger._
+import services.MonitoringService
 import utils.FlattenableEither._
 
 @Singleton
-class PushHandlerController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+class PushHandlerController @Inject()(cc: ControllerComponents, metricClient: MonitoringService) extends AbstractController(cc) {
 
   def receivePush(): Action[AnyContent] = Action { implicit request =>
     val res = parsePushMessageBody[GooglePushMessageWrapper](request.body)
@@ -40,7 +42,9 @@ class PushHandlerController @Inject()(cc: ControllerComponents) extends Abstract
   private def resultToEither[A](jsResult: JsResult[A]): Either[Exception, A] = {
     jsResult match {
       case JsSuccess(value, _) => Right(value)
-      case JsError(errors)     => Left(DeserializationException("Failure to deserialize push request from pub sub", errors))
+      case JsError(errors)     =>
+        metricClient.incrementDeserializationFailure("IncomingPubSubDeserialization")
+        Left(DeserializationException("Failure to deserialize push request from pub sub", errors))
     }
   }
 }

--- a/app/controllers/PushHandlerController.scala
+++ b/app/controllers/PushHandlerController.scala
@@ -43,7 +43,7 @@ class PushHandlerController @Inject()(cc: ControllerComponents, monitoringServic
     jsResult match {
       case JsSuccess(value, _) => Right(value)
       case JsError(errors)     =>
-        monitoringService.addDeserializationFailure("IncomingPubSubDeserialization")
+        monitoringService.addDeserializationFailure()
         Left(DeserializationException("Failure to deserialize push request from pub sub", errors))
     }
   }

--- a/app/controllers/PushHandlerController.scala
+++ b/app/controllers/PushHandlerController.scala
@@ -13,7 +13,7 @@ import services.MonitoringService
 import utils.FlattenableEither._
 
 @Singleton
-class PushHandlerController @Inject()(cc: ControllerComponents, metricClient: MonitoringService) extends AbstractController(cc) {
+class PushHandlerController @Inject()(cc: ControllerComponents, monitoringService: MonitoringService) extends AbstractController(cc) {
 
   def receivePush(): Action[AnyContent] = Action { implicit request =>
     val res = parsePushMessageBody[GooglePushMessageWrapper](request.body)
@@ -43,7 +43,7 @@ class PushHandlerController @Inject()(cc: ControllerComponents, metricClient: Mo
     jsResult match {
       case JsSuccess(value, _) => Right(value)
       case JsError(errors)     =>
-        metricClient.incrementDeserializationFailure("IncomingPubSubDeserialization")
+        monitoringService.addDeserializationFailure("IncomingPubSubDeserialization")
         Left(DeserializationException("Failure to deserialize push request from pub sub", errors))
     }
   }

--- a/app/model/NotificationType.scala
+++ b/app/model/NotificationType.scala
@@ -9,7 +9,7 @@ sealed abstract class NotificationType(val value: Int, name: String) extends Int
 case object NotificationType extends IntEnum[NotificationType] with IntPlayJsonValueEnum[NotificationType] {
   override def values: immutable.IndexedSeq[NotificationType] = findValues
 
-//  (1) SUBSCRIPTION_RECOVERED - A subscription was recovered from account hold.
+  //  (1) SUBSCRIPTION_RECOVERED - A subscription was recovered from account hold.
   case object SubscriptionRecovered extends NotificationType(1, "SUBSCRIPTION_RECOVERED")
   //  (2) SUBSCRIPTION_RENEWED - An active subscription was renewed.
   case object SubscriptionRenewed extends NotificationType(2, "SUBSCRIPTION_RENEWED")
@@ -29,4 +29,9 @@ case object NotificationType extends IntEnum[NotificationType] with IntPlayJsonV
   case object SubscriptionPriceChangeConfirmed extends NotificationType(8, "SUBSCRIPTION_PRICE_CHANGE_CONFIRMED")
   //  (9) SUBSCRIPTION_DEFERRED - A subscription's recurrence time has been extended.
   case object SubscriptionDeferred extends NotificationType(9, "SUBSCRIPTION_DEFERRED")
+  //  (12) SUBSCRIPTION_REVOKED - A subscription has been revoked from the user before the expiration time.
+  case object SubscriptionRevoked extends NotificationType(12, "SUBSCRIPTION_REVOKED")
+  //  (13) SUBSCRIPTION_EXPIRED - A subscription has expired.
+  case object SubscriptionExpired extends NotificationType(13, "SUBSCRIPTION_EXPIRED")
+
 }

--- a/app/services/CloudWatchService.scala
+++ b/app/services/CloudWatchService.scala
@@ -9,9 +9,9 @@ trait MonitoringService {
 
   def put(metricName: String, dimensionName: String, metricValue: String): Unit
 
-  def incrementSkuTypeCounter(metricName: String, skuType: SKUType): Unit
+  def addSkuTypeCounter(metricName: String, skuType: SKUType): Unit
 
-  def incrementDeserializationFailure(reason: String): Unit
+  def addDeserializationFailure(reason: String): Unit
 
 }
 
@@ -36,11 +36,11 @@ class CloudWatchService(cloudWatchAsyncClient: AmazonCloudWatchAsync, qualifier:
     cloudWatchAsyncClient.putMetricDataAsync(request, CloudWatchService.LoggingAsyncHandler)
   }
 
-  def incrementSkuTypeCounter(metricName: String, skuType: SKUType): Unit = {
+  def addSkuTypeCounter(metricName: String, skuType: SKUType): Unit = {
     put(metricName, "sku-type", skuType.toString)
   }
 
-  def incrementDeserializationFailure(reason: String): Unit = {
+  def addDeserializationFailure(reason: String): Unit = {
     put("DeserializationFailure", "DeserializationFailure", reason)
   }
 

--- a/app/services/CloudWatchService.scala
+++ b/app/services/CloudWatchService.scala
@@ -5,15 +5,23 @@ import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetri
 import model.SKUType
 import play.api.Logger._
 
-trait MonitoringService
+trait MonitoringService {
+
+  def put(metricName: String, dimensionName: String, metricValue: String): Unit
+
+  def incrementSkuTypeCounter(metricName: String, skuType: SKUType): Unit
+
+  def incrementDeserializationFailure(reason: String): Unit
+
+}
 
 class CloudWatchService(cloudWatchAsyncClient: AmazonCloudWatchAsync, qualifier: String) extends MonitoringService {
   private val namespace = s"support-subscribe-with-google-$qualifier"
 
-  def put(metricName: String, skuType: SKUType): Unit = {
+  def put(metricName: String, dimensionName: String, metricValue: String): Unit = {
     val skuTypeDimension = new Dimension()
-      .withName("sku-type")
-      .withValue(skuType.toString)
+      .withName(dimensionName)
+      .withValue(metricValue)
 
     val metric = new MetricDatum()
       .withValue(1d)
@@ -27,6 +35,15 @@ class CloudWatchService(cloudWatchAsyncClient: AmazonCloudWatchAsync, qualifier:
 
     cloudWatchAsyncClient.putMetricDataAsync(request, CloudWatchService.LoggingAsyncHandler)
   }
+
+  def incrementSkuTypeCounter(metricName: String, skuType: SKUType): Unit = {
+    put(metricName, "sku-type", skuType.toString)
+  }
+
+  def incrementDeserializationFailure(reason: String): Unit = {
+    put("DeserializationFailure", "DeserializationFailure", reason)
+  }
+
 }
 
 object CloudWatchService {

--- a/test/controllers/PushHandlerControllerSpec.scala
+++ b/test/controllers/PushHandlerControllerSpec.scala
@@ -1,18 +1,24 @@
 package controllers
 
 import fixtures.TestFixtures
+import org.scalatest.mock.MockitoSugar
 import org.scalatest.{Matchers, WordSpecLike}
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
 import play.api.libs.json.Json
 import play.api.test.{FakeRequest, Injecting}
 import play.api.test.Helpers._
+import services.MonitoringService
 
 
-class PushHandlerControllerSpec extends WordSpecLike with Matchers with GuiceOneAppPerTest with Injecting {
+class PushHandlerControllerSpec extends WordSpecLike with Matchers with GuiceOneAppPerTest with Injecting with MockitoSugar {
+
+
+  val mockMetricClient = mock[MonitoringService]
+
 
   "Push Handler" must {
     "handle a correctly formed post request with json data" in {
-      val controller = new PushHandlerController(stubControllerComponents())
+      val controller = new PushHandlerController(stubControllerComponents(), mockMetricClient)
 
       val action = controller.receivePush().apply(FakeRequest("POST", "/push/handle-message")
         .withJsonBody(Json.toJson(TestFixtures.googlePushMessageWrapper)))
@@ -22,7 +28,7 @@ class PushHandlerControllerSpec extends WordSpecLike with Matchers with GuiceOne
     }
 
     "handle a incorrect notification json" in {
-      val controller = new PushHandlerController(stubControllerComponents())
+      val controller = new PushHandlerController(stubControllerComponents(), mockMetricClient)
 
       val action = controller.receivePush().apply(FakeRequest("POST", "/push/handle-message")
         .withJsonBody(Json.toJson(TestFixtures.googlePushMessageWithInvalidBody)))
@@ -32,7 +38,7 @@ class PushHandlerControllerSpec extends WordSpecLike with Matchers with GuiceOne
     }
 
     "handle an empty request body" in {
-      val controller = new PushHandlerController(stubControllerComponents())
+      val controller = new PushHandlerController(stubControllerComponents(), mockMetricClient)
 
       val action = controller.receivePush().apply(FakeRequest("POST", "/push/handle-message"))
 

--- a/test/controllers/PushHandlerControllerSpec.scala
+++ b/test/controllers/PushHandlerControllerSpec.scala
@@ -1,7 +1,9 @@
 package controllers
 
 import fixtures.TestFixtures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
+import org.mockito.Mockito._
+import org.mockito.{ Matchers => Match }
 import org.scalatest.{Matchers, WordSpecLike}
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
 import play.api.libs.json.Json
@@ -10,15 +12,19 @@ import play.api.test.Helpers._
 import services.MonitoringService
 
 
-class PushHandlerControllerSpec extends WordSpecLike with Matchers with GuiceOneAppPerTest with Injecting with MockitoSugar {
-
-
+class PushHandlerFixture() extends MockitoSugar {
   val mockMetricClient = mock[MonitoringService]
 
+}
+
+
+class PushHandlerControllerSpec extends WordSpecLike with Matchers with GuiceOneAppPerTest with Injecting with MockitoSugar {
 
   "Push Handler" must {
     "handle a correctly formed post request with json data" in {
-      val controller = new PushHandlerController(stubControllerComponents(), mockMetricClient)
+      val fixture = new PushHandlerFixture()
+
+      val controller = new PushHandlerController(stubControllerComponents(), fixture.mockMetricClient)
 
       val action = controller.receivePush().apply(FakeRequest("POST", "/push/handle-message")
         .withJsonBody(Json.toJson(TestFixtures.googlePushMessageWrapper)))
@@ -28,17 +34,20 @@ class PushHandlerControllerSpec extends WordSpecLike with Matchers with GuiceOne
     }
 
     "handle a incorrect notification json" in {
-      val controller = new PushHandlerController(stubControllerComponents(), mockMetricClient)
+      val fixture = new PushHandlerFixture()
+      val controller = new PushHandlerController(stubControllerComponents(), fixture.mockMetricClient)
 
       val action = controller.receivePush().apply(FakeRequest("POST", "/push/handle-message")
         .withJsonBody(Json.toJson(TestFixtures.googlePushMessageWithInvalidBody)))
 
-
       status(action) shouldBe NO_CONTENT
+      verify(fixture.mockMetricClient, times(1)).addDeserializationFailure(Match.any())
     }
 
     "handle an empty request body" in {
-      val controller = new PushHandlerController(stubControllerComponents(), mockMetricClient)
+      val fixture = new PushHandlerFixture()
+
+      val controller = new PushHandlerController(stubControllerComponents(), fixture.mockMetricClient)
 
       val action = controller.receivePush().apply(FakeRequest("POST", "/push/handle-message"))
 

--- a/test/controllers/PushHandlerControllerSpec.scala
+++ b/test/controllers/PushHandlerControllerSpec.scala
@@ -41,7 +41,7 @@ class PushHandlerControllerSpec extends WordSpecLike with Matchers with GuiceOne
         .withJsonBody(Json.toJson(TestFixtures.googlePushMessageWithInvalidBody)))
 
       status(action) shouldBe NO_CONTENT
-      verify(fixture.mockMetricClient, times(1)).addDeserializationFailure(Match.any())
+      verify(fixture.mockMetricClient, times(1)).addDeserializationFailure()
     }
 
     "handle an empty request body" in {

--- a/test/model/DeveloperNotificationSpec.scala
+++ b/test/model/DeveloperNotificationSpec.scala
@@ -22,7 +22,27 @@ class DeveloperNotificationSpec extends WordSpecLike with Matchers {
 
       val jsValue = Json.parse("""{"version":"1.0","packageName":"com.guardian","eventTimeMillis":"1549369095263","subscriptionNotification":{"version":"1.0","notificationType":2,"purchaseToken":"","subscriptionId":"uk.co.guardian.subscription"}}""")
       Json.stringify(Json.toJson[DeveloperNotification](subscriptionDeveloperNotification)) shouldBe Json.stringify(jsValue)
+    }
 
+    "Fail to serialize a developer subscription notification with a non-enum notification type" in {
+
+      val subscriptionNotification = SubscriptionNotification("1.0",
+        NotificationType.SubscriptionRenewed,
+        "",
+        "uk.co.guardian.subscription")
+
+      val currentTime = System.currentTimeMillis()
+      val subscriptionDeveloperNotification: DeveloperNotification = SubscriptionDeveloperNotification(
+        "1.0",
+        "com.guardian",
+        1549369095263L,
+        subscriptionNotification)
+
+      val jsValue = Json.parse("""{"version":"1.0","packageName":"com.guardian","eventTimeMillis":"1549369095263","subscriptionNotification":{"version":"1.0","notificationType":1337,"purchaseToken":"","subscriptionId":"uk.co.guardian.subscription"}}""")
+
+      val notification = jsValue.validate[DeveloperNotification]
+
+      notification shouldBe a[JsError]
     }
 
     "Serialize a developer test notification" in {

--- a/test/model/NotificationTypeSpec.scala
+++ b/test/model/NotificationTypeSpec.scala
@@ -6,7 +6,7 @@ class NotificationTypeSpec extends WordSpecLike with Matchers {
 
   "NotificationType enum" must {
     "have 9 types" in {
-      NotificationType.values.size shouldBe 9
+      NotificationType.values.size shouldBe 11
     }
     "be creatable from Int" in {
       NotificationType.withValue(1) shouldBe NotificationType.SubscriptionRecovered
@@ -18,6 +18,8 @@ class NotificationTypeSpec extends WordSpecLike with Matchers {
       NotificationType.withValue(7) shouldBe NotificationType.SubscriptionRestarted
       NotificationType.withValue(8) shouldBe NotificationType.SubscriptionPriceChangeConfirmed
       NotificationType.withValue(9) shouldBe NotificationType.SubscriptionDeferred
+      NotificationType.withValue(12) shouldBe NotificationType.SubscriptionRevoked
+      NotificationType.withValue(13) shouldBe NotificationType.SubscriptionExpired
     }
   }
 }

--- a/test/services/CloudWatchServiceSpec.scala
+++ b/test/services/CloudWatchServiceSpec.scala
@@ -16,7 +16,7 @@ class CloudWatchServiceSpec extends WordSpec with Matchers with ScalaFutures wit
     "put" in {
       val cloudWatchService = new CloudWatchService(mockAmazonCloudWatchAsync, "TEST")
 
-      cloudWatchService.incrementSkuTypeCounter("metric-name", SKUType.Recurring)
+      cloudWatchService.addSkuTypeCounter("metric-name", SKUType.Recurring)
 
       val skuTypeDimension = new Dimension()
         .withName("sku-type")

--- a/test/services/CloudWatchServiceSpec.scala
+++ b/test/services/CloudWatchServiceSpec.scala
@@ -16,7 +16,7 @@ class CloudWatchServiceSpec extends WordSpec with Matchers with ScalaFutures wit
     "put" in {
       val cloudWatchService = new CloudWatchService(mockAmazonCloudWatchAsync, "TEST")
 
-      cloudWatchService.put("metric-name", SKUType.Recurring)
+      cloudWatchService.incrementSkuTypeCounter("metric-name", SKUType.Recurring)
 
       val skuTypeDimension = new Dimension()
         .withName("sku-type")


### PR DESCRIPTION
In This PR:

New notification types - This it to match the documentation at: https://developer.android.com/google/play/billing/realtime_developer_notifications

On deserialization failure, i.e we cannot find a particular event type or we are missing a key we now send a cloudwatch metric out so we can trace the rate of failure