### PR TITLE
Add API gateway & SQS provisioning to cfn

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -31,6 +31,7 @@ Parameters:
   CertificateARN:
     Description: SSL Certificate
     Type: String
+
 Resources:
   AutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -54,6 +55,7 @@ Resources:
         - Key: Stage
           Value: !Ref Stage
           PropagateAtLaunch: true
+
   LaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
@@ -70,6 +72,7 @@ Resources:
             export INSTANCE_ID=$(hostname -i)
             dpkg -i /tmp/${App}_1.0_all.deb
             subscribe-with-google
+
   AppRole:
     Type: AWS::IAM::Role
     Properties:
@@ -201,3 +204,63 @@ Resources:
           FromPort: 443
           ToPort: 443
           CidrIp: 0.0.0.0/0
+
+  SQSQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "google-pub-sub-${Stage}"
+
+  SQSRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: api-gateway-google-pub-sub-sqs-access-role
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: api-gateway-google-pub-sub-sqs-access-policy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Action: sqs:SendMessage
+                Effect: Allow
+                Resource: !GetAtt SQSQueue.Arn
+
+  MessageApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: !Sub "google-pub-sub-api-${Stage}"
+      Description: Receives notifications from Google Pub Sub. Currently used by Subscribe with Google.
+
+  MessageResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      PathPart: "message"
+      RestApiId: !Ref "MessageApi"
+      ParentId: !GetAtt MessageApi.RootResourceId
+
+  ReceiveMessageMethod:
+    Type: AWS::ApiGateway::Method
+    DependsOn: SQSQueue
+    Properties:
+      RestApiId: !Ref "MessageApi"
+      ResourceId: !Ref "MessageResource"
+      HttpMethod: POST
+      MethodResponses:
+        - StatusCode: 200
+      AuthorizationType: NONE
+      Integration:
+        Type: AWS
+        Uri: !Sub "arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/google-pub-sub-${Stage}"
+        Credentials: !GetAtt "SQSRole.Arn"
+        IntegrationHttpMethod: POST
+        IntegrationResponses:
+          - StatusCode: 200
+        RequestParameters:
+          integration.request.querystring.Action: "'SendMessage'"
+          integration.request.querystring.MessageBody: method.request.body


### PR DESCRIPTION
This provisions:
* SQS Queue `google-pub-sub-${Stage}`
* API gateway `google-pub-sub-api-${Stage}`
  * With resource  `POST /message`
  * The POST request is forwarded to the SQS queue
* IAM Role & policy to grant API gateway access SQS queue

Output from AWS API gateway test console:
<img width="552" alt="screen shot 2019-02-25 at 15 25 15" src="https://user-images.githubusercontent.com/249676/53348009-2ab1ca00-3912-11e9-8525-2b9cd2827ec1.png">

Some helpful resources from along the way:
* https://dzone.com/articles/creating-aws-service-proxy-for-amazon-sqs
* https://stackoverflow.com/questions/41097441/how-to-integrate-api-gateway-with-sqs
* https://www.profit4cloud.nl/blog/async-api-with-api-gateway-and-the-sqs-alternative/
* https://cloudhut.io/connect-aws-api-gateway-to-sqs-923cf312bf78