### PR TITLE
Add API gateway secret auth

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -231,6 +231,79 @@ Resources:
                 Effect: Allow
                 Resource: !GetAtt SQSQueue.Arn
 
+  MessageApiAuthLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+  MessageApiAuthLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: !Sub >
+          function generatePolicy(principalId, effect, resource) {
+            return {
+              'principalId': principalId,
+              'policyDocument': {
+                'Version': '2012-10-17',
+                'Statement': [{
+                  'Action': 'execute-api:Invoke',
+                  'Effect': effect,
+                  'Resource': resource
+                }]
+              }
+            };
+          }
+
+          export.handler = (event, context, cb) => {
+            const secret = event.queryStringParameters.secret;
+            if (secret == '{{resolve:secretsmanager:subscribe_with_google_pub_sub_{Stage}:SecretString:secret_key}}') {
+              cb(null, generatePolicy('user', 'Allow', event.methodArn));
+            } else {
+              cb(null, generatePolicy('user', 'Deny', event.methodArn));
+            }
+          }
+      Handler: index.handler
+      Role: !GetAtt MessageApiAuthLambdaRole.Arn
+      Runtime: nodejs8.10
+
+  MessageApiAuthorizeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: Lambda
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              Effect: Allow
+              Action: lambda:invokeFunction
+              Resource: !GetAtt MessageApiAuthLambda.Arn
+
+  MessageApiAuthorizer:
+    Type: AWS::ApiGateway::Authorizer
+    Properties:
+      AuthorizerCredentials: !GetAtt MessageApiAuthorizeRole.Arn
+      AuthorizeUri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/20115-03-31/functions/${MessageApiAuthLambda.Arn}/invocations
+      IdentifySource: method.request.querystring.secret
+      Name: api-gateway-google-pub-sub-api-authorizer
+      RestApiId: !Ref MessageApi
+      Type: REQUEST
+
   MessageApi:
     Type: AWS::ApiGateway::RestApi
     Properties:
@@ -253,7 +326,8 @@ Resources:
       HttpMethod: POST
       MethodResponses:
         - StatusCode: 200
-      AuthorizationType: NONE
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref MessageApiAuthorizer
       Integration:
         Type: AWS
         Uri: !Sub "arn:aws:apigateway:${AWS::Region}:sqs:path//${AWS::AccountId}/google-pub-sub-${Stage}"

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -247,28 +247,31 @@ Resources:
   MessageApiAuthLambda:
     Type: AWS::Lambda::Function
     Properties:
+      Environment:
+        Variables:
+          SECRET_KEY: !Sub '{{resolve:secretsmanager:subscribe_with_google_pub_sub_${Stage}:SecretString:secret_key}}'
       Code:
         ZipFile: !Sub >
-          function generatePolicy(principalId, effect, resource) {
+          function generatePolicy(effect, resource) {
             return {
-              'principalId': principalId,
-              'policyDocument': {
-                'Version': '2012-10-17',
-                'Statement': [{
-                  'Action': 'execute-api:Invoke',
-                  'Effect': effect,
-                  'Resource': resource
+              principalId: 'user',
+              policyDocument: {
+                Version: '2012-10-17',
+                Statement: [{
+                  Action: 'execute-api:Invoke',
+                  Effect: effect,
+                  Resource: resource
                 }]
               }
             };
           }
 
-          export.handler = (event, context, cb) => {
+          exports.handler = (event, context, cb) => {
             const secret = event.queryStringParameters.secret;
-            if (secret == '{{resolve:secretsmanager:subscribe_with_google_pub_sub_{Stage}:SecretString:secret_key}}') {
-              cb(null, generatePolicy('user', 'Allow', event.methodArn));
+            if (secret == process.env.SECRET_KEY) {
+              cb(null, generatePolicy('Allow', event.methodArn));
             } else {
-              cb(null, generatePolicy('user', 'Deny', event.methodArn));
+              cb(null, generatePolicy('Deny', event.methodArn));
             }
           }
       Handler: index.handler
@@ -298,8 +301,8 @@ Resources:
     Type: AWS::ApiGateway::Authorizer
     Properties:
       AuthorizerCredentials: !GetAtt MessageApiAuthorizeRole.Arn
-      AuthorizeUri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/20115-03-31/functions/${MessageApiAuthLambda.Arn}/invocations
-      IdentifySource: method.request.querystring.secret
+      AuthorizerUri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/20  15-03-31/functions/${MessageApiAuthLambda.Arn}/invocations
+      IdentitySource: method.request.querystring.secret
       Name: api-gateway-google-pub-sub-api-authorizer
       RestApiId: !Ref MessageApi
       Type: REQUEST


### PR DESCRIPTION
Add:
* Secret key authorisation, checked via an API gateway lambda based authorizer.
* Our secret key is set in Google PubSub config as a query param on the endpoint and and in AWS secrets manager under key `subscribe_with_google_pub_sub_${Stage}:SecretString:secret_key`.

I plan to investigate moving lambda code into its own js file. It's currently in the cf yaml file 🤢 